### PR TITLE
fix: too short horizontal scroll on wide video

### DIFF
--- a/src/ZoomFunction.js
+++ b/src/ZoomFunction.js
@@ -70,13 +70,13 @@ export class ZoomFunction {
 	}
 
 	moveLeft(salt) {
-		const available = this.player.offsetHeight * this.available;
+		const available = this.player.offsetWidth * this.available;
 		this.state.moveX = Math.max(- available, Math.min(available, this.state.moveX + (salt ?? this.state.saltMoveX)));
 		this._move();
 	}
 
 	moveRight() {
-		const available = this.player.offsetHeight * this.available;
+		const available = this.player.offsetWidth * this.available;
 		this.state.moveX = Math.max(- available, this.state.moveX - this.state.saltMoveX);
 		this._move();
 	}


### PR DESCRIPTION
@giovanesantossilva 
I have fixed my mistake.
Scroll is too short on wide video for horizontal move.
My bad.